### PR TITLE
sm8150-common: Remove libaacwrapper from PRODUCT_PACKAGES

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -458,7 +458,6 @@ PRODUCT_COPY_FILES += \
 
 # WiFi Display
 PRODUCT_PACKAGES += \
-    libaacwrapper \
     libnl
 
 PRODUCT_BOOT_JARS += \


### PR DESCRIPTION
 * It does not exist at all and is replaced by libwfdaac.